### PR TITLE
Some quality of live improvements

### DIFF
--- a/lib/Utility.js
+++ b/lib/Utility.js
@@ -3,7 +3,7 @@ const Util = imports.misc.util;
 const GLib = imports.gi.GLib;
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 
-const COMMAND_TO_SWITCH_GPU_PROFILE = "pkexec prime-select {profile}; gnome-session-quit --logout";
+const COMMAND_TO_SWITCH_GPU_PROFILE = "pkexec {prime-path} {profile}; gnome-session-quit --logout";
 
 const EXTENSION_ICON_FILE_NAME = '/img/icon.png';
 
@@ -70,10 +70,42 @@ function isBatteryPlugged() {
     return false;
 }
 
+/*
+It might be that on some systems (openSUSE for example) prime-select is located at
+/usr/sbin instead of /usr/bin which is usually not included in a default useres $PATH
+So we need to locate the excutable.
+*/
+function _findPrimeSelect(){
+    let is_sbin = _test_prime_path(true);
+    if(is_sbin){
+        return '/usr/sbin/prime-select';
+    } else {
+        let is_bin = _test_prime_path(false);
+        if(is_bin){
+            return '/usr/bin/prime-select';
+        }
+    }
+    //In case the user has set some addional $PATH includes we did not checked then
+    //just return the binary name.
+    return 'prime-select'
+}
+
+function _test_prime_path(superuser){
+    let raw_cmd = 'which /usr/{path}/prime-select 2>/dev/null || echo FALSE';
+    let final_cmd = superuser ? raw_cmd.replace('{path}', 'sbin') : raw_cmd.replace('{path}', 'bin');
+    
+    let [ok, outbuf, err, exit] = GLib.spawn_command_line_sync(final_cmd);
+    let decoder = new TextDecoder();
+    let out = decoder.decode(outbuf);
+
+    return out.toLowerCase().includes("prime-select");
+}
+
 function _execSwitch(profile) {
     // exec switch
     Util.spawn(['/bin/bash', '-c', COMMAND_TO_SWITCH_GPU_PROFILE
         .replace("{profile}", profile)
+        .replace("{prime-path}", _findPrimeSelect())
     ]);
 }
 

--- a/lib/Utility.js
+++ b/lib/Utility.js
@@ -3,7 +3,7 @@ const Util = imports.misc.util;
 const GLib = imports.gi.GLib;
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 
-const COMMAND_TO_SWITCH_GPU_PROFILE = "pkexec prime-select boot {profile}; gnome-session-quit --reboot";
+const COMMAND_TO_SWITCH_GPU_PROFILE = "pkexec prime-select {profile}; gnome-session-quit --logout";
 
 const EXTENSION_ICON_FILE_NAME = '/img/icon.png';
 

--- a/lib/Utility.js
+++ b/lib/Utility.js
@@ -16,20 +16,13 @@ const ICON_NVIDIA_FILE_NAME = '/img/nvidia_icon_plain.svg';
 const ICON_HYBRID_FILE_NAME = '/img/intel_icon_plain.svg';
 
 function getCurrentProfile() {
-    let [ok, outbuf, err, exit] = GLib.spawn_command_line_sync('prime-select get-current');
+    let [ok, outbuf, err, exit] = GLib.spawn_command_line_sync(_findPrimeSelect() + ' get-current');
 
     let decoder = new TextDecoder();
     let out = decoder.decode(outbuf);
-    log(out);
-    let is_nvidia = out.toLowerCase().includes("nvidia");
-    let is_intel = out.toLowerCase().includes("intel");
+    let driver = out.split("\n")[0].split(":")[1].trim().toLowerCase();
 
-    if (is_nvidia && is_intel)
-        return GPU_PROFILE_HYBRID;
-    else if (is_nvidia)
-        return GPU_PROFILE_NVIDIA;
-    else
-        return GPU_PROFILE_INTEGRATED;
+    return driver;
 }
 
 function getIconForProfile(p) {
@@ -44,8 +37,6 @@ function getIconForProfile(p) {
             return Gio.icon_new_for_string(Me.dir.get_path() + ICON_INTEL_FILE_NAME);
     }
 }
-
-
 
 function capitalizeFirstLetter(string) {
     return string.charAt(0).toUpperCase() + string.slice(1);
@@ -124,3 +115,4 @@ function switchHybrid(all_settings) {
 function switchNvidia(all_settings) {
     _execSwitch(GPU_PROFILE_NVIDIA);
 }
+

--- a/ui/AttachedToBatteryView.js
+++ b/ui/AttachedToBatteryView.js
@@ -42,19 +42,19 @@ class AttachedToBatteryToggle extends QuickSettings.QuickMenuToggle {
             Utility.switchNvidia();
             super.subtitle = 'Nvidia';
             super.gicon = Utility.getIconForProfile(Utility.getCurrentProfile());
-            this.menu.setHeader('selection-mode-symbolic', 'Nvidia (Reboot needed)', 'Choose a GPU mode');
+            this.menu.setHeader('selection-mode-symbolic', 'Nvidia (Relog needed)', 'Choose a GPU mode');
         });
         this._itemsSection.addAction('Offload', () => {
             Utility.switchHybrid();
             super.subtitle = 'Offload';
             super.gicon = Utility.getIconForProfile(Utility.getCurrentProfile());
-            this.menu.setHeader('selection-mode-symbolic', 'Offload (Reboot needed)', 'Choose a GPU mode');
+            this.menu.setHeader('selection-mode-symbolic', 'Offload (Relog needed)', 'Choose a GPU mode');
         });
         this._itemsSection.addAction('Intel', () => {
             Utility.switchIntegrated();
             super.subtitle = 'Intel';
             super.gicon = Utility.getIconForProfile(Utility.getCurrentProfile());
-            this.menu.setHeader('selection-mode-symbolic', 'Intel (Reboot needed)', 'Choose a GPU mode');
+            this.menu.setHeader('selection-mode-symbolic', 'Intel (Relog needed)', 'Choose a GPU mode');
         });
         this.menu.addMenuItem(this._itemsSection);
 

--- a/ui/TopBarView.js
+++ b/ui/TopBarView.js
@@ -86,30 +86,35 @@ class TopBarView extends PanelMenu.Button {
 
         // check GPU profile
         const gpu_profile = Utility.getCurrentProfile();
-        if (gpu_profile === Utility.GPU_PROFILE_INTEGRATED) {
-            this.hybrid_menu_item.remove_child(this.icon_selector);
-            this.nvidia_menu_item.remove_child(this.icon_selector);
-            this.integrated_menu_item.add_child(this.icon_selector);
-            this.icon_top = new St.Icon({
-                gicon : Gio.icon_new_for_string(Me.dir.get_path() + Utility.ICON_INTEL_FILE_NAME),
-                style_class: 'system-status-icon',
-            });
-        } else if(gpu_profile === Utility.GPU_PROFILE_HYBRID) {
-            this.integrated_menu_item.remove_child(this.icon_selector);
-            this.nvidia_menu_item.remove_child(this.icon_selector);
-            this.hybrid_menu_item.add_child(this.icon_selector);
-            this.icon_top = new St.Icon({
-                gicon : Gio.icon_new_for_string(Me.dir.get_path() + Utility.ICON_HYBRID_FILE_NAME),
-                style_class: 'system-status-icon',
-            });
-        } else {
-            this.integrated_menu_item.remove_child(this.icon_selector);
-            this.hybrid_menu_item.remove_child(this.icon_selector);
-            this.nvidia_menu_item.add_child(this.icon_selector);
-            this.icon_top = new St.Icon({
-                gicon : Gio.icon_new_for_string(Me.dir.get_path() + Utility.ICON_NVIDIA_FILE_NAME),
-                style_class: 'system-status-icon',
-            });
+        switch(gpu_profile){
+            case Utility.GPU_PROFILE_INTEGRATED:
+                this.hybrid_menu_item.remove_child(this.icon_selector);
+                this.nvidia_menu_item.remove_child(this.icon_selector);
+                this.integrated_menu_item.add_child(this.icon_selector);
+                this.icon_top = new St.Icon({
+                    gicon : Gio.icon_new_for_string(Me.dir.get_path() + Utility.ICON_INTEL_FILE_NAME),
+                    style_class: 'system-status-icon',
+                });
+            break;
+            case Utility.GPU_PROFILE_HYBRID:
+                this.integrated_menu_item.remove_child(this.icon_selector);
+                this.nvidia_menu_item.remove_child(this.icon_selector);
+                this.hybrid_menu_item.add_child(this.icon_selector);
+                this.icon_top = new St.Icon({
+                    gicon : Gio.icon_new_for_string(Me.dir.get_path() + Utility.ICON_HYBRID_FILE_NAME),
+                    style_class: 'system-status-icon',
+                });
+            break;
+            default:
+                this.integrated_menu_item.remove_child(this.icon_selector);
+                this.hybrid_menu_item.remove_child(this.icon_selector);
+                this.nvidia_menu_item.add_child(this.icon_selector);
+                this.icon_top = new St.Icon({
+                    gicon : Gio.icon_new_for_string(Me.dir.get_path() + Utility.ICON_NVIDIA_FILE_NAME),
+                    style_class: 'system-status-icon',
+                });
+            break;
+            
         }
         this.add_child(this.icon_top);
     }


### PR DESCRIPTION
Hello there in this pull request I'd like to slightly refine this extention with the following changes:

## Do not call prime-select boot
I found it inconvenient that this extension always changed the boot behaviour of prime-select as the user might have had set a special boot behaviour on purpose.
Like me, I want my Laptop to always boot into intel mode and only switch to offload or nvidia on demand without changing the default.
Also a full reboot takes noticeable longer that logging out and in again.

Therefore I removed the 'boot' parameter from the prime-select command and request a --logout instead of a --reboot from gnome-session-quit

Also I feel like changing the boot mode should belong into "More Settings" which as of now does nothing but this would be a nice addition to allow the user to change the boot behaviour there in a future version.  
Or maybe give the user the choice if they always want to change the boot and do a full system reboot or want the login-logout behaviour.

## Better discover of prime-select binary
On my system the extension by default did not worked as it could not located the "prime-select" binary even though it is on my system.
The reason for this was that prime-select was located at /usr/sbin and this directory is not in my users $PATH.
A quick fix was to add /usr/sbin/ to my $PATH but this might not be wanted by some users.

Therefore I added a few functions to search the prime-select binary in /usr/sbin and if not available there look up /usr/bin and if not there then just call 'prime-select' without any additional path.

This fixes #1 

## Improvements to select current icon
Also I found that selecting the proper icon for prime-select get-current was a bit unreliable which is also improved with this PR.


Kind regards,
V.